### PR TITLE
Service domain changed

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for {{ $dist->name }}
 
 {{ $NEXT }}
+    - Service domain changed
 
 0.001     2015-06-17 14:37:59+09:00 Asia/Seoul
     - first release

--- a/lib/SMS/Send/KR/APIStore.pm
+++ b/lib/SMS/Send/KR/APIStore.pm
@@ -12,7 +12,7 @@ use parent qw( SMS::Send::Driver );
 use HTTP::Tiny;
 use JSON;
 
-our $URL     = "http://api.openapi.io/ppurio/1/message";
+our $URL     = "http://api.apistore.co.kr/ppurio/1/message";
 our $AGENT   = 'SMS-Send-KR-APIStore/' . $SMS::Send::KR::APIStore::VERSION;
 our $TIMEOUT = 3;
 our $TYPE    = 'SMS';


### PR DESCRIPTION
> 보낸 사람: "API스토어" apistore.help@kt.com
> 제목: [API스토어]대용량 SMS서비스 장애 관련
> 날짜: 2016년 10월 28일 오후 3시 21분 32초 GMT+9
> 받는 사람: "이름없음" 10001if@theopencloset.net
> 
> 안녕하세요 API스토어 입니다.
> 
> 금일 서비스 장애 관련 하여 수정 확인 하였는데 개발적인 이슈가 있어 전달 드립니다.
> 
> 기존 호출 하시는 URL이 문제가 있어, 해당 도메인을 바꿔야 하는 이슈가 발생 하였습니다.
> 
> 기존: http://api.openapi.io/ppurio/1/message/SMS
> 
> 수정: http://api.apistore.co.kr/ppurio/1/message/SMS
> 
> 위 내용으로 수정하여 API 호출 하시면 문제 없이 발송이 가능하니 확인 부탁드립니다.
> 
> 감사 합니다.
